### PR TITLE
Move to first page when send heart

### DIFF
--- a/scripts/com.r2studio.Tsum/index.js
+++ b/scripts/com.r2studio.Tsum/index.js
@@ -2051,6 +2051,11 @@ Tsum.prototype.taskSendHearts = function() {
   var startTime = Date.now();
   var retry = 0;
   var times = 0;
+  this.goFriendPage();
+  var page = this.findPage(1, 300);
+  if (page == "FriendPage") {
+    this.friendPageGoTop();
+  }
   while(this.isRunning) {
     times++;
     if (times % 15 == 14) {


### PR DESCRIPTION
For current Tsum version, it will send heart from the lower rank friends. This patch will send heart from the first page.